### PR TITLE
The Readline is now a well behaving readable stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ $stdio->on('line', function ($line) {
 You can control various aspects of the console input through the [`Readline`](#readline),
 so read on..
 
+Using the `line` event is the recommended way to wait for user input.
+Alternatively, using the `Readline` as a readable stream is considered advanced
+usage.
+
 ### Readline
 
 The [`Readline`](#readline) class is responsible for reacting to user input and presenting a prompt to the user.
@@ -88,6 +92,12 @@ You can access the current instance through the [`Stdio`](#stdio):
 ```php
 $readline = $stdio->getReadline();
 ```
+
+See above for waiting for user input.
+Alternatively, the `Readline` is also a well-behaving readable stream
+(implementing React's `ReadableStreamInterface`) that emits each complete
+line as a `data` event (without the trailing newline). This is considered
+advanced usage.
 
 #### Prompt
 

--- a/src/Readline.php
+++ b/src/Readline.php
@@ -3,6 +3,8 @@
 namespace Clue\React\Stdio;
 
 use Evenement\EventEmitter;
+use React\Stream\ReadableStreamInterface;
+use React\Stream\WritableStreamInterface;
 
 class Readline extends EventEmitter
 {
@@ -34,8 +36,11 @@ class Readline extends EventEmitter
     private $output;
     private $sequencer;
 
-    public function __construct($output)
+    public function __construct(ReadableStreamInterface $input, WritableStreamInterface $output)
     {
+        // input data emits a single char into readline
+        $input->on('data', array($this, 'onChar'));
+
         $this->output = $output;
 
         $this->sequencer = new Sequencer();

--- a/src/Stdio.php
+++ b/src/Stdio.php
@@ -22,18 +22,17 @@ class Stdio extends CompositeStream
 
         $this->output = new Stdout(STDOUT);
 
-        $this->readline = $readline = new Readline($this->output);
+        $this->readline = new Readline($this->input, $this->output);
 
         $that = $this;
 
-        // input data emits a single char into readline
-        $this->input->on('data', function ($data) use ($that, $readline) {
+        // stdin emits single chars
+        $this->input->on('data', function ($data) use ($that) {
             $that->emit('char', array($data, $that));
-            $readline->onChar($data);
         });
 
         // readline data emits a new line
-        $readline->on('data', function($line) use ($that) {
+        $this->readline->on('data', function($line) use ($that) {
             $that->emit('line', array($line, $that));
         });
 

--- a/tests/ReadlineTest.php
+++ b/tests/ReadlineTest.php
@@ -1,13 +1,19 @@
 <?php
 
 use Clue\React\Stdio\Readline;
+use React\Stream\ReadableStream;
 
 class ReadlineTest extends TestCase
 {
+    private $input;
+    private $output;
+    private $readline;
+
     public function setUp()
     {
-        $this->input = $this->getMock('React\Stream\ReadableStreamInterface');
-        $this->output = $this->getMockBuilder('Clue\React\Stdio\Stdout')->disableOriginalConstructor()->getMock();
+        $this->input = new ReadableStream();
+        $this->output = $this->getMock('React\Stream\WritableStreamInterface');
+
         $this->readline = new Readline($this->input, $this->output);
     }
 
@@ -480,7 +486,7 @@ class ReadlineTest extends TestCase
     private function pushInputBytes(Readline $readline, $bytes)
     {
         foreach (str_split($bytes, 1) as $byte) {
-            $readline->onChar($byte);
+            $this->input->emit('data', array($byte));
         }
     }
 }

--- a/tests/ReadlineTest.php
+++ b/tests/ReadlineTest.php
@@ -6,8 +6,9 @@ class ReadlineTest extends TestCase
 {
     public function setUp()
     {
+        $this->input = $this->getMock('React\Stream\ReadableStreamInterface');
         $this->output = $this->getMockBuilder('Clue\React\Stdio\Stdout')->disableOriginalConstructor()->getMock();
-        $this->readline = new Readline($this->output);
+        $this->readline = new Readline($this->input, $this->output);
     }
 
     public function testSettersReturnSelf()

--- a/tests/StdioTest.php
+++ b/tests/StdioTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use React\EventLoop\Factory;
+use Clue\React\Stdio\Stdio;
+
+class StdioTest extends TestCase
+{
+    private $loop;
+
+    public function setUp()
+    {
+        $this->loop = Factory::create();
+    }
+
+    public function testCtor()
+    {
+        $stdio = new Stdio($this->loop);
+    }
+}


### PR DESCRIPTION
This is a BC break because the ctor arguments have been changed. This class is only used internally, so it should not affect any consumers of this lib.

This is done in preparation for #17 and #15 and #30.