### PR TITLE
The Stdio is now a well-behaving duplex stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,16 @@ $loop = React\EventLoop\Factory::create();
 $stdio = new Stdio($loop);
 ```
 
+See below for waiting for user input and writing output.
+Alternatively, the `Stdio` is also a well-behaving duplex stream
+(implementing React's `DuplexStreamInterface`) that emits each complete
+line as a `data` event (including the trailing newline). This is considered
+advanced usage.
+
 #### Output
+
+The `Stdio` is a well-behaving writable stream
+implementing React's `WritableStreamInterface`.
 
 The `writeln($line)` method can be used to print a line to console output.
 A trailing newline will be added automatically.
@@ -58,9 +67,23 @@ $stdio->write('hello');
 $stdio->write(" world\n");
 ```
 
+The `overwrite($text)` method can be used to overwrite/replace the last
+incomplete line with the given text:
+
+```php
+$stdio->write('Loading…');
+$stdio->overwrite('Done!');
+```
+
+Alternatively, you can also use the `Stdio` as a writable stream.
+You can `pipe()` any readable stream into this stream.
+
 #### Input
 
-The `Stdio` will emit a `line` event for every line read from console input.
+The `Stdio` is a well-behaving readable stream
+implementing React's `ReadableStreamInterface`.
+
+It will emit a `line` event for every line read from console input.
 The event will contain the input buffer as-is, without the trailing newline.
 You can register any number of event handlers like this:
 
@@ -78,6 +101,10 @@ so read on..
 Using the `line` event is the recommended way to wait for user input.
 Alternatively, using the `Readline` as a readable stream is considered advanced
 usage.
+
+Alternatively, you can also use the `Stdio` as a readable stream, which emits
+each complete line as a `data` event (including the trailing newline).
+This can be used to `pipe()` this stream into other writable streams.
 
 ### Readline
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.3",
         "react/event-loop": "0.3.*|0.4.*",
-        "react/stream": "0.3.*|0.4.*"
+        "react/stream": "^0.4.2"
     },
     "autoload": {
         "psr-4": { "Clue\\React\\Stdio\\": "src/" }

--- a/examples/progress.php
+++ b/examples/progress.php
@@ -8,19 +8,16 @@ require __DIR__ . '/../vendor/autoload.php';
 $loop = React\EventLoop\Factory::create();
 
 $stdio = new Stdio($loop);
-$stdio->getInput()->close();
-
 $stdio->writeln('Will print (fake) progress and then exit');
 
 $progress = new ProgressBar($stdio);
 $progress->setMaximum(mt_rand(20, 200));
 
-$loop->addPeriodicTimer(0.2, function ($timer) use ($stdio, $progress) {
+$loop->addPeriodicTimer(0.1, function ($timer) use ($stdio, $progress) {
     $progress->advance();
 
     if ($progress->isComplete()) {
-        $stdio->overwrite();
-        $stdio->writeln("Finished processing nothing!");
+        $stdio->overwrite("Finished processing nothing!" . PHP_EOL);
 
         $stdio->end();
         $timer->cancel();

--- a/src/Stdio.php
+++ b/src/Stdio.php
@@ -11,9 +11,9 @@ class Stdio extends CompositeStream
 {
     private $input;
     private $output;
-
     private $readline;
-    private $needsNewline = false;
+
+    private $incompleteLine = '';
 
     public function __construct(LoopInterface $loop, ReadableStreamInterface $input = null, WritableStreamInterface $output = null, Readline $readline = null)
     {
@@ -41,7 +41,11 @@ class Stdio extends CompositeStream
         });
 
         // readline data emits a new line
-        $this->readline->on('data', function($line) use ($that) {
+        $incomplete =& $this->incompleteLine;
+        $this->readline->on('data', function($line) use ($that, &$incomplete) {
+            // readline emits a new line on enter, so start with a blank line
+            $incomplete = '';
+
             $that->emit('line', array($line, $that));
         });
     }
@@ -66,25 +70,40 @@ class Stdio extends CompositeStream
 
     public function write($data)
     {
-        // switch back to last output position
+        // clear readline prompt in order to overwrite with data
         $this->readline->clear();
 
-        // Erase characters from cursor to end of line
-        $this->output->write("\r\033[K");
-
-        // move one line up?
-        if ($this->needsNewline) {
+        // move one line up if the last write did not end with a newline
+        if ($this->incompleteLine !== '') {
             $this->output->write("\033[A");
+            $this->output->write("\r\033[" . $this->width($this->incompleteLine) . "C");
         }
 
+        // write actual data
         $this->output->write($data);
 
-        $this->needsNewline = substr($data, -1) !== "\n";
+        // following write will have have to append to this line if it does not end with a newline
+        $endsWithNewline = substr($data, -1) === "\n";
 
-        // repeat current prompt + linebuffer
-        if ($this->needsNewline) {
+        if ($endsWithNewline) {
+            // line ends with newline, so this is line is considered complete
+            $this->incompleteLine = '';
+        } else {
+            // always end data with newline in order to append readline on next line
             $this->output->write("\n");
+
+            $lastNewline = strrpos($data, "\n");
+
+            if ($lastNewline === false) {
+                // contains no newline at all, everything is incomplete
+                $this->incompleteLine .= $data;
+            } else {
+                // contains a newline, everything behind it is incomplete
+                $this->incompleteLine = (string)substr($data, $lastNewline + 1);
+            }
         }
+
+        // restore original readline prompt and line buffer
         $this->readline->redraw();
     }
 
@@ -95,9 +114,13 @@ class Stdio extends CompositeStream
 
     public function overwrite($data = '')
     {
-        // TODO: remove existing characters
+        if ($this->incompleteLine !== '') {
+            // move one line up, move to start of line and clear everything
+            $data = "\033[A\r\033[K" . $data;
+            $this->incompleteLine = '';
+        }
 
-        $this->write("\r" . $data);
+        $this->write($data);
     }
 
     public function end($data = null)
@@ -131,5 +154,10 @@ class Stdio extends CompositeStream
     public function getReadline()
     {
         return $this->readline;
+    }
+
+    private function width($str)
+    {
+        return mb_strwidth($str, 'utf-8') - 2 * substr_count($str, "\x08");
     }
 }

--- a/tests/StdioTest.php
+++ b/tests/StdioTest.php
@@ -3,6 +3,8 @@
 use React\EventLoop\Factory;
 use Clue\React\Stdio\Stdio;
 use Clue\React\Stdio\Readline;
+use React\Stream\ReadableStream;
+use React\Stream\WritableStream;
 
 class StdioTest extends TestCase
 {
@@ -262,5 +264,243 @@ class StdioTest extends TestCase
         $stdio->writeln('world');
 
         $this->assertEquals("\r\033[K" . "hello\n" . "\r\033[K" . "> input" . "\r\033[K" . "world\n" . "\r\033[K" . "> input", $buffer);
+    }
+
+    public function testPauseWillBeForwardedToInput()
+    {
+        $input = $this->getMock('React\Stream\ReadableStreamInterface');
+        $output = $this->getMock('React\Stream\WritableStreamInterface');
+
+        //$readline = $this->getMockBuilder('Clue\React\Stdio\Readline')->disableOriginalConstructor()->getMock();
+        $readline = new Readline($input, $output);
+
+        $stdio = new Stdio($this->loop, $input, $output, $readline);
+
+        $input->expects($this->once())->method('pause');
+
+        $stdio->pause();
+    }
+
+    public function testResumeWillBeForwardedToInput()
+    {
+        $input = $this->getMock('React\Stream\ReadableStreamInterface');
+        $output = $this->getMock('React\Stream\WritableStreamInterface');
+
+        //$readline = $this->getMockBuilder('Clue\React\Stdio\Readline')->disableOriginalConstructor()->getMock();
+        $readline = new Readline($input, $output);
+
+        $stdio = new Stdio($this->loop, $input, $output, $readline);
+
+        $input->expects($this->once())->method('resume');
+
+        $stdio->resume();
+    }
+
+    public function testReadableWillBeForwardedToInput()
+    {
+        $input = $this->getMock('React\Stream\ReadableStreamInterface');
+        $output = $this->getMock('React\Stream\WritableStreamInterface');
+
+        //$readline = $this->getMockBuilder('Clue\React\Stdio\Readline')->disableOriginalConstructor()->getMock();
+        $readline = new Readline($input, $output);
+
+        $stdio = new Stdio($this->loop, $input, $output, $readline);
+
+        $input->expects($this->once())->method('isReadable')->willReturn(true);
+
+        $this->assertTrue($stdio->isReadable());
+    }
+
+    public function testPipeWillReturnDestStream()
+    {
+        $input = $this->getMock('React\Stream\ReadableStreamInterface');
+        $output = $this->getMock('React\Stream\WritableStreamInterface');
+
+        //$readline = $this->getMockBuilder('Clue\React\Stdio\Readline')->disableOriginalConstructor()->getMock();
+        $readline = new Readline($input, $output);
+
+        $stdio = new Stdio($this->loop, $input, $output, $readline);
+
+        $dest = $this->getMock('React\Stream\WritableStreamInterface');
+
+        $ret = $stdio->pipe($dest);
+
+        $this->assertSame($dest, $ret);
+    }
+
+    public function testWritableWillBeForwardedToOutput()
+    {
+        $input = $this->getMock('React\Stream\ReadableStreamInterface');
+        $output = $this->getMock('React\Stream\WritableStreamInterface');
+
+        //$readline = $this->getMockBuilder('Clue\React\Stdio\Readline')->disableOriginalConstructor()->getMock();
+        $readline = new Readline($input, $output);
+
+        $stdio = new Stdio($this->loop, $input, $output, $readline);
+
+        $output->expects($this->once())->method('isWritable')->willReturn(true);
+
+        $this->assertTrue($stdio->isWritable());
+    }
+
+    public function testCloseWillCloseInputAndOutput()
+    {
+        $input = $this->getMock('React\Stream\ReadableStreamInterface');
+        $output = $this->getMock('React\Stream\WritableStreamInterface');
+
+        //$readline = $this->getMockBuilder('Clue\React\Stdio\Readline')->disableOriginalConstructor()->getMock();
+        $readline = new Readline($input, $output);
+
+        $stdio = new Stdio($this->loop, $input, $output, $readline);
+
+        $input->expects($this->once())->method('close');
+        $output->expects($this->once())->method('close');
+
+        $stdio->close();
+    }
+
+    public function testCloseTwiceWillCloseInputAndOutputOnlyOnce()
+    {
+        $input = $this->getMock('React\Stream\ReadableStreamInterface');
+        $output = $this->getMock('React\Stream\WritableStreamInterface');
+
+        //$readline = $this->getMockBuilder('Clue\React\Stdio\Readline')->disableOriginalConstructor()->getMock();
+        $readline = new Readline($input, $output);
+
+        $stdio = new Stdio($this->loop, $input, $output, $readline);
+
+        $input->expects($this->once())->method('close');
+        $output->expects($this->once())->method('close');
+
+        $stdio->close();
+        $stdio->close();
+    }
+
+    public function testEndWillCloseInputAndEndOutput()
+    {
+        $input = $this->getMock('React\Stream\ReadableStreamInterface');
+        $output = $this->getMock('React\Stream\WritableStreamInterface');
+
+        //$readline = $this->getMockBuilder('Clue\React\Stdio\Readline')->disableOriginalConstructor()->getMock();
+        $readline = new Readline($input, $output);
+
+        $stdio = new Stdio($this->loop, $input, $output, $readline);
+
+        $input->expects($this->once())->method('close');
+        $output->expects($this->once())->method('end');
+
+        $stdio->end();
+    }
+
+    public function testEndWithDataWillWriteAndCloseInputAndEndOutput()
+    {
+        $input = $this->getMock('React\Stream\ReadableStreamInterface');
+        $output = $this->getMock('React\Stream\WritableStreamInterface');
+
+        //$readline = $this->getMockBuilder('Clue\React\Stdio\Readline')->disableOriginalConstructor()->getMock();
+        $readline = new Readline($input, $output);
+
+        $stdio = new Stdio($this->loop, $input, $output, $readline);
+
+        $output->expects($this->atLeastOnce())->method('write');
+
+        $input->expects($this->once())->method('close');
+        $output->expects($this->once())->method('end');
+
+        $stdio->end('test');
+    }
+
+    public function testWriteAfterEndWillNotWriteToOutput()
+    {
+        $input = $this->getMock('React\Stream\ReadableStreamInterface');
+        $output = $this->getMock('React\Stream\WritableStreamInterface');
+
+        //$readline = $this->getMockBuilder('Clue\React\Stdio\Readline')->disableOriginalConstructor()->getMock();
+        $readline = new Readline($input, $output);
+
+        $stdio = new Stdio($this->loop, $input, $output, $readline);
+        $stdio->end();
+
+        $output->expects($this->never())->method('write');
+
+        $stdio->write('test');
+    }
+
+    public function testEndTwiceWillCloseInputAndEndOutputOnce()
+    {
+        $input = $this->getMock('React\Stream\ReadableStreamInterface');
+        $output = $this->getMock('React\Stream\WritableStreamInterface');
+
+        //$readline = $this->getMockBuilder('Clue\React\Stdio\Readline')->disableOriginalConstructor()->getMock();
+        $readline = new Readline($input, $output);
+
+        $stdio = new Stdio($this->loop, $input, $output, $readline);
+
+        $input->expects($this->once())->method('close');
+        $output->expects($this->once())->method('end');
+
+        $stdio->end();
+        $stdio->end();
+    }
+
+    public function testDataEventWillBeForwarded()
+    {
+        $input = $this->getMock('React\Stream\ReadableStreamInterface');
+        $output = $this->getMock('React\Stream\WritableStreamInterface');
+
+        //$readline = $this->getMockBuilder('Clue\React\Stdio\Readline')->disableOriginalConstructor()->getMock();
+        $readline = new Readline($input, $output);
+
+        $stdio = new Stdio($this->loop, $input, $output, $readline);
+
+        $stdio->on('data', $this->expectCallableOnceWith("hello\n"));
+        $stdio->on('line', $this->expectCallableOnceWith('hello'));
+
+        $readline->emit('data', array('hello'));
+    }
+
+    public function testEndEventWillBeForwarded()
+    {
+        $input = new ReadableStream();
+        $output = $this->getMock('React\Stream\WritableStreamInterface');
+
+        //$readline = $this->getMockBuilder('Clue\React\Stdio\Readline')->disableOriginalConstructor()->getMock();
+        $readline = new Readline($input, $output);
+
+        $stdio = new Stdio($this->loop, $input, $output, $readline);
+
+        $stdio->on('end', $this->expectCallableOnce());
+
+        $input->emit('end');
+    }
+
+    public function testErrorEventFromInputWillBeForwarded()
+    {
+        $input = new ReadableStream();
+        $output = $this->getMock('React\Stream\WritableStreamInterface');
+
+        //$readline = $this->getMockBuilder('Clue\React\Stdio\Readline')->disableOriginalConstructor()->getMock();
+        $readline = new Readline($input, $output);
+
+        $stdio = new Stdio($this->loop, $input, $output, $readline);
+
+        $stdio->on('error', $this->expectCallableOnce());
+
+        $input->emit('error', array(new \RuntimeException()));
+    }
+
+    public function testErrorEventFromOutputWillBeForwarded()
+    {
+        $input = $this->getMock('React\Stream\ReadableStreamInterface');
+        $output = new WritableStream();
+
+        //$readline = $this->getMockBuilder('Clue\React\Stdio\Readline')->disableOriginalConstructor()->getMock();
+        $readline = new Readline($input, $output);
+
+        $stdio = new Stdio($this->loop, $input, $output, $readline);
+
+        $stdio->on('error', $this->expectCallableOnce());
+
+        $output->emit('error', array(new \RuntimeException()));
     }
 }

--- a/tests/StdioTest.php
+++ b/tests/StdioTest.php
@@ -34,6 +34,23 @@ class StdioTest extends TestCase
         $this->assertSame($readline, $stdio->getReadline());
     }
 
+    public function testWriteEmptyStringWillNotWriteToOutput()
+    {
+        $input = $this->getMock('React\Stream\ReadableStreamInterface');
+        $output = $this->getMock('React\Stream\WritableStreamInterface');
+
+        //$readline = $this->getMockBuilder('Clue\React\Stdio\Readline')->disableOriginalConstructor()->getMock();
+        $readline = new Readline($input, $output);
+        $readline->setPrompt('> ');
+        $readline->setInput('input');
+
+        $stdio = new Stdio($this->loop, $input, $output, $readline);
+
+        $output->expects($this->never())->method('write');
+
+        $stdio->write('');
+    }
+
     public function testWriteWillClearReadlineWriteOutputAndRestoreReadline()
     {
         $input = $this->getMock('React\Stream\ReadableStreamInterface');
@@ -56,7 +73,7 @@ class StdioTest extends TestCase
         $this->assertEquals("\r\033[K" . "test\n" . "\r\033[K" . "> input", $buffer);
     }
 
-    public function testWriteAgainWillClearReadlineMoveToPreviousLineWriteOutputAndRestoreReadline()
+    public function testWriteAgainWillMoveToPreviousLineWriteOutputAndRestoreReadlinePosition()
     {
         $input = $this->getMock('React\Stream\ReadableStreamInterface');
         $output = $this->getMock('React\Stream\WritableStreamInterface');
@@ -77,10 +94,10 @@ class StdioTest extends TestCase
 
         $stdio->write('world');
 
-        $this->assertEquals("\r\033[K" . "\033[A" . "\r\033[5C" . "world\n" . "\r\033[K" . "> input", $buffer);
+        $this->assertEquals("\033[A" . "\r\033[5C" . "world\n" . "\033[7C", $buffer);
     }
 
-    public function testWriteAgainWithBackspaceWillClearReadlineMoveToPreviousLineWriteOutputAndRestoreReadline()
+    public function testWriteAgainWithBackspaceWillMoveToPreviousLineWriteOutputAndRestoreReadlinePosition()
     {
         $input = $this->getMock('React\Stream\ReadableStreamInterface');
         $output = $this->getMock('React\Stream\WritableStreamInterface');
@@ -101,7 +118,7 @@ class StdioTest extends TestCase
 
         $stdio->write("\x08 world!");
 
-        $this->assertEquals("\r\033[K" . "\033[A" . "\r\033[6C" . "\x08 world!\n" . "\r\033[K" . "> input", $buffer);
+        $this->assertEquals("\033[A" . "\r\033[6C" . "\x08 world!\n" . "\033[7C", $buffer);
     }
 
     public function testWriteAgainWithNewlinesWillClearReadlineMoveToPreviousLineWriteOutputAndRestoreReadline()

--- a/tests/StdioTest.php
+++ b/tests/StdioTest.php
@@ -33,4 +33,217 @@ class StdioTest extends TestCase
         $this->assertSame($output, $stdio->getOutput());
         $this->assertSame($readline, $stdio->getReadline());
     }
+
+    public function testWriteWillClearReadlineWriteOutputAndRestoreReadline()
+    {
+        $input = $this->getMock('React\Stream\ReadableStreamInterface');
+        $output = $this->getMock('React\Stream\WritableStreamInterface');
+
+        //$readline = $this->getMockBuilder('Clue\React\Stdio\Readline')->disableOriginalConstructor()->getMock();
+        $readline = new Readline($input, $output);
+        $readline->setPrompt('> ');
+        $readline->setInput('input');
+
+        $stdio = new Stdio($this->loop, $input, $output, $readline);
+
+        $buffer = '';
+        $output->expects($this->any())->method('write')->will($this->returnCallback(function ($data) use (&$buffer) {
+            $buffer .= $data;
+        }));
+
+        $stdio->write('test');
+
+        $this->assertEquals("\r\033[K" . "test\n" . "\r\033[K" . "> input", $buffer);
+    }
+
+    public function testWriteAgainWillClearReadlineMoveToPreviousLineWriteOutputAndRestoreReadline()
+    {
+        $input = $this->getMock('React\Stream\ReadableStreamInterface');
+        $output = $this->getMock('React\Stream\WritableStreamInterface');
+
+        //$readline = $this->getMockBuilder('Clue\React\Stdio\Readline')->disableOriginalConstructor()->getMock();
+        $readline = new Readline($input, $output);
+        $readline->setPrompt('> ');
+        $readline->setInput('input');
+
+        $stdio = new Stdio($this->loop, $input, $output, $readline);
+
+        $stdio->write('hello');
+
+        $buffer = '';
+        $output->expects($this->any())->method('write')->will($this->returnCallback(function ($data) use (&$buffer) {
+            $buffer .= $data;
+        }));
+
+        $stdio->write('world');
+
+        $this->assertEquals("\r\033[K" . "\033[A" . "\r\033[5C" . "world\n" . "\r\033[K" . "> input", $buffer);
+    }
+
+    public function testWriteAgainWithBackspaceWillClearReadlineMoveToPreviousLineWriteOutputAndRestoreReadline()
+    {
+        $input = $this->getMock('React\Stream\ReadableStreamInterface');
+        $output = $this->getMock('React\Stream\WritableStreamInterface');
+
+        //$readline = $this->getMockBuilder('Clue\React\Stdio\Readline')->disableOriginalConstructor()->getMock();
+        $readline = new Readline($input, $output);
+        $readline->setPrompt('> ');
+        $readline->setInput('input');
+
+        $stdio = new Stdio($this->loop, $input, $output, $readline);
+
+        $stdio->write('hello!');
+
+        $buffer = '';
+        $output->expects($this->any())->method('write')->will($this->returnCallback(function ($data) use (&$buffer) {
+            $buffer .= $data;
+        }));
+
+        $stdio->write("\x08 world!");
+
+        $this->assertEquals("\r\033[K" . "\033[A" . "\r\033[6C" . "\x08 world!\n" . "\r\033[K" . "> input", $buffer);
+    }
+
+    public function testWriteAgainWithNewlinesWillClearReadlineMoveToPreviousLineWriteOutputAndRestoreReadline()
+    {
+        $input = $this->getMock('React\Stream\ReadableStreamInterface');
+        $output = $this->getMock('React\Stream\WritableStreamInterface');
+
+        //$readline = $this->getMockBuilder('Clue\React\Stdio\Readline')->disableOriginalConstructor()->getMock();
+        $readline = new Readline($input, $output);
+        $readline->setPrompt('> ');
+        $readline->setInput('input');
+
+        $stdio = new Stdio($this->loop, $input, $output, $readline);
+
+        $stdio->write("first" . "\n" . "sec");
+
+        $buffer = '';
+        $output->expects($this->any())->method('write')->will($this->returnCallback(function ($data) use (&$buffer) {
+            $buffer .= $data;
+        }));
+
+        $stdio->write("ond" . "\n" . "third");
+
+        $this->assertEquals("\r\033[K" . "\033[A" . "\r\033[3C" . "ond\nthird\n" . "\r\033[K" . "> input", $buffer);
+    }
+
+    public function testWriteAfterReadlineInputWillClearReadlineWriteOutputAndRestoreReadline()
+    {
+        $input = $this->getMock('React\Stream\ReadableStreamInterface');
+        $output = $this->getMock('React\Stream\WritableStreamInterface');
+
+        //$readline = $this->getMockBuilder('Clue\React\Stdio\Readline')->disableOriginalConstructor()->getMock();
+        $readline = new Readline($input, $output);
+        $readline->setPrompt('> ');
+
+        $stdio = new Stdio($this->loop, $input, $output, $readline);
+
+        $stdio->write('incomplete');
+
+        $readline->emit('data', array('test'));
+        $readline->setInput('input');
+
+        $buffer = '';
+        $output->expects($this->any())->method('write')->will($this->returnCallback(function ($data) use (&$buffer) {
+            $buffer .= $data;
+        }));
+
+        $stdio->writeln('test');
+
+        $this->assertEquals("\r\033[K" . "test\n" . "\r\033[K" . "> input", $buffer);
+    }
+
+    public function testOverwriteWillClearReadlineMoveToPreviousLineWriteOutputAndRestoreReadline()
+    {
+        $input = $this->getMock('React\Stream\ReadableStreamInterface');
+        $output = $this->getMock('React\Stream\WritableStreamInterface');
+
+        //$readline = $this->getMockBuilder('Clue\React\Stdio\Readline')->disableOriginalConstructor()->getMock();
+        $readline = new Readline($input, $output);
+        $readline->setPrompt('> ');
+        $readline->setInput('input');
+
+        $stdio = new Stdio($this->loop, $input, $output, $readline);
+
+        $stdio->write('first');
+
+        $buffer = '';
+        $output->expects($this->any())->method('write')->will($this->returnCallback(function ($data) use (&$buffer) {
+            $buffer .= $data;
+        }));
+
+        $stdio->overwrite('overwrite');
+
+        $this->assertEquals("\r\033[K" . "\033[A" . "\r\033[K" . "overwrite\n" . "\r\033[K" . "> input", $buffer);
+    }
+
+    public function testOverwriteAfterNewlineWillClearReadlineAndWriteOutputAndRestoreReadline()
+    {
+        $input = $this->getMock('React\Stream\ReadableStreamInterface');
+        $output = $this->getMock('React\Stream\WritableStreamInterface');
+
+        //$readline = $this->getMockBuilder('Clue\React\Stdio\Readline')->disableOriginalConstructor()->getMock();
+        $readline = new Readline($input, $output);
+        $readline->setPrompt('> ');
+        $readline->setInput('input');
+
+        $stdio = new Stdio($this->loop, $input, $output, $readline);
+
+        $stdio->write("first\n");
+
+        $buffer = '';
+        $output->expects($this->any())->method('write')->will($this->returnCallback(function ($data) use (&$buffer) {
+            $buffer .= $data;
+        }));
+
+        $stdio->overwrite('overwrite');
+
+        $this->assertEquals("\r\033[K" . "overwrite\n" . "\r\033[K" . "> input", $buffer);
+    }
+
+    public function testWriteLineWillClearReadlineWriteOutputAndRestoreReadline()
+    {
+        $input = $this->getMock('React\Stream\ReadableStreamInterface');
+        $output = $this->getMock('React\Stream\WritableStreamInterface');
+
+        //$readline = $this->getMockBuilder('Clue\React\Stdio\Readline')->disableOriginalConstructor()->getMock();
+        $readline = new Readline($input, $output);
+        $readline->setPrompt('> ');
+        $readline->setInput('input');
+
+        $stdio = new Stdio($this->loop, $input, $output, $readline);
+
+        $buffer = '';
+        $output->expects($this->any())->method('write')->will($this->returnCallback(function ($data) use (&$buffer) {
+            $buffer .= $data;
+        }));
+
+        $stdio->writeln('test');
+
+        $this->assertEquals("\r\033[K" . "test\n" . "\r\033[K" . "> input", $buffer);
+    }
+
+    public function testWriteTwoLinesWillClearReadlineWriteOutputAndRestoreReadline()
+    {
+        $input = $this->getMock('React\Stream\ReadableStreamInterface');
+        $output = $this->getMock('React\Stream\WritableStreamInterface');
+
+        //$readline = $this->getMockBuilder('Clue\React\Stdio\Readline')->disableOriginalConstructor()->getMock();
+        $readline = new Readline($input, $output);
+        $readline->setPrompt('> ');
+        $readline->setInput('input');
+
+        $stdio = new Stdio($this->loop, $input, $output, $readline);
+
+        $buffer = '';
+        $output->expects($this->any())->method('write')->will($this->returnCallback(function ($data) use (&$buffer) {
+            $buffer .= $data;
+        }));
+
+        $stdio->writeln('hello');
+        $stdio->writeln('world');
+
+        $this->assertEquals("\r\033[K" . "hello\n" . "\r\033[K" . "> input" . "\r\033[K" . "world\n" . "\r\033[K" . "> input", $buffer);
+    }
 }

--- a/tests/StdioTest.php
+++ b/tests/StdioTest.php
@@ -2,6 +2,7 @@
 
 use React\EventLoop\Factory;
 use Clue\React\Stdio\Stdio;
+use Clue\React\Stdio\Readline;
 
 class StdioTest extends TestCase
 {
@@ -12,8 +13,24 @@ class StdioTest extends TestCase
         $this->loop = Factory::create();
     }
 
-    public function testCtor()
+    public function testCtorDefaultArgs()
     {
         $stdio = new Stdio($this->loop);
+        $stdio->close();
+    }
+
+    public function testCtorArgsWillBeReturnedByGetters()
+    {
+        $input = $this->getMock('React\Stream\ReadableStreamInterface');
+        $output = $this->getMock('React\Stream\WritableStreamInterface');
+
+        //$readline = $this->getMockBuilder('Clue\React\Stdio\Readline')->disableOriginalConstructor()->getMock();
+        $readline = new Readline($input, $output);
+
+        $stdio = new Stdio($this->loop, $input, $output, $readline);
+
+        $this->assertSame($input, $stdio->getInput());
+        $this->assertSame($output, $stdio->getOutput());
+        $this->assertSame($readline, $stdio->getReadline());
     }
 }


### PR DESCRIPTION
The `Stdio` is now a well-behaving duplex stream which will now emit each complete line as `data` events. If you need access to the raw input byte stream, consider using the `Stdin` as a readable stream instead.

The writable behavior is now also more predictable and stable. The test suite has been improved significantly.

This changeset also improves output performance significantly, most notably the output should no longer "flicker".

This is a BC break because the ctor arguments have been changed. This ctor is only used internally, so it should not affect any consumers of this lib.

Closes #17 and closes #34.
Builds on top of #32 and #33.