### PR TITLE
Explicitly end stream on CTRL+D and emit final data on EOF without EOL

### DIFF
--- a/examples/01-periodic.php
+++ b/examples/01-periodic.php
@@ -16,8 +16,8 @@ $timer = $loop->addPeriodicTimer(0.5, function () use ($stdio) {
 });
 
 // react to commands the user entered
-$stdio->on('line', function ($line) use ($stdio, $loop, $timer) {
-    $stdio->writeln('you just said: ' . $line . ' (' . strlen($line) . ')');
+$stdio->on('data', function ($line) use ($stdio, $loop, $timer) {
+    $stdio->writeln('you just said: ' . addcslashes($line, "\0..\37") . ' (' . strlen($line) . ')');
 
     $loop->cancelTimer($timer);
     $stdio->end();

--- a/examples/01-periodic.php
+++ b/examples/01-periodic.php
@@ -16,10 +16,16 @@ $timer = $loop->addPeriodicTimer(0.5, function () use ($stdio) {
 });
 
 // react to commands the user entered
-$stdio->on('line', function ($line) use ($stdio, $timer) {
+$stdio->on('line', function ($line) use ($stdio, $loop, $timer) {
     $stdio->writeln('you just said: ' . $line . ' (' . strlen($line) . ')');
 
-    $timer->cancel();
+    $loop->cancelTimer($timer);
+    $stdio->end();
+});
+
+// cancel periodic timer if STDIN closed
+$stdio->on('end', function () use ($stdio, $loop, $timer) {
+    $loop->cancelTimer($timer);
     $stdio->end();
 });
 

--- a/src/Readline.php
+++ b/src/Readline.php
@@ -47,7 +47,8 @@ class Readline extends EventEmitter implements ReadableStreamInterface
             "\n" => 'onKeyEnter',
             "\x7f" => 'onKeyBackspace',
             "\t" => 'onKeyTab',
-            "\x04" => 'closeInput', // CTRL+D
+
+            "\x04" => 'handleEnd', // CTRL+D
 
             "\033[A" => 'onKeyUp',
             "\033[B" => 'onKeyDown',
@@ -804,6 +805,10 @@ class Readline extends EventEmitter implements ReadableStreamInterface
     /** @internal */
     public function handleEnd()
     {
+        if ($this->linebuffer !== '') {
+            $this->processLine();
+        }
+
         if (!$this->closed) {
             $this->emit('end');
             $this->close();
@@ -837,14 +842,6 @@ class Readline extends EventEmitter implements ReadableStreamInterface
         Util::pipe($this, $dest, $options);
 
         return $dest;
-    }
-
-    public function closeInput()
-    {
-        if ($this->linebuffer !== '') {
-            $this->processLine();
-        }
-        $this->handleEnd();
     }
 
     public function close()

--- a/src/Readline.php
+++ b/src/Readline.php
@@ -47,6 +47,7 @@ class Readline extends EventEmitter implements ReadableStreamInterface
             "\n" => 'onKeyEnter',
             "\x7f" => 'onKeyBackspace',
             "\t" => 'onKeyTab',
+            "\x04" => 'closeInput', // CTRL+D
 
             "\033[A" => 'onKeyUp',
             "\033[B" => 'onKeyDown',
@@ -836,6 +837,14 @@ class Readline extends EventEmitter implements ReadableStreamInterface
         Util::pipe($this, $dest, $options);
 
         return $dest;
+    }
+
+    public function closeInput()
+    {
+        if ($this->linebuffer !== '') {
+            $this->processLine();
+        }
+        $this->handleEnd();
     }
 
     public function close()

--- a/src/Stdio.php
+++ b/src/Stdio.php
@@ -241,7 +241,7 @@ class Stdio extends EventEmitter implements DuplexStreamInterface
     /** @internal */
     public function handleEnd()
     {
-        $this->emit('end', array());
+        $this->emit('end');
     }
 
     /** @internal */

--- a/tests/ReadlineTest.php
+++ b/tests/ReadlineTest.php
@@ -981,9 +981,22 @@ class ReadlineTest extends TestCase
 
     public function testEmitEndWillEmitEndAndClose()
     {
+        $this->readline->on('data', $this->expectCallableNever());
         $this->readline->on('end', $this->expectCallableOnce());
         $this->readline->on('close', $this->expectCallableOnce());
 
+        $this->input->emit('end');
+
+        $this->assertFalse($this->readline->isReadable());
+    }
+
+    public function testEmitEndAfterDataWillEmitDataAndEndAndClose()
+    {
+        $this->readline->on('data', $this->expectCallableOnce('hello'));
+        $this->readline->on('end', $this->expectCallableOnce());
+        $this->readline->on('close', $this->expectCallableOnce());
+
+        $this->input->emit('data', array('hello'));
         $this->input->emit('end');
 
         $this->assertFalse($this->readline->isReadable());

--- a/tests/ReadlineTest.php
+++ b/tests/ReadlineTest.php
@@ -223,6 +223,24 @@ class ReadlineTest extends TestCase
         $this->input->emit('data', array("\n"));
     }
 
+    public function testEndInputWithoutDataOnCtrlD()
+    {
+        $this->readline->on('data', $this->expectCallableNever());
+        $this->readline->on('end', $this->expectCallableOnce());
+        $this->readline->on('close', $this->expectCallableOnce());
+
+        $this->input->emit('data', array("\x04"));
+    }
+
+    public function testEndInputWithIncompleteLineOnCtrlD()
+    {
+        $this->readline->on('data', $this->expectCallableOnceWith('hello'));
+        $this->readline->on('end', $this->expectCallableOnce());
+        $this->readline->on('close', $this->expectCallableOnce());
+
+        $this->input->emit('data', array("hello\x04"));
+    }
+
     public function testWriteSimpleCharWritesOnce()
     {
         $this->output->expects($this->once())->method('write')->with($this->equalTo("\r\033[K" . "k"));


### PR DESCRIPTION
This is also a prerequisite for #16
Refs #15