### PR TITLE
Deprecate input helpers, use Stdio as ReadableStreamInterface instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,10 +154,11 @@ $readline = $stdio->getReadline();
 ```
 
 See above for waiting for user input.
+
 Alternatively, the `Readline` is also a well-behaving readable stream
 (implementing ReactPHP's `ReadableStreamInterface`) that emits each complete
-line as a `data` event (without the trailing newline). This is considered
-advanced usage.
+line as a `data` event (without the trailing newline).
+This is considered advanced usage.
 
 #### Prompt
 
@@ -312,11 +313,12 @@ If you want to automatically add everything from the user input to the history,
 you may want to use something like this:
 
 ```php
-$readline->on('data', function ($line) use ($readline) {
+$stdio->on('data', function ($line) use ($readline) {
+    $line = rtrim($line);
     $all = $readline->listHistory();
     
     // skip empty line and duplicate of previous line
-    if (trim($line) !== '' && $line !== end($all)) {
+    if ($line !== '' && $line !== end($all)) {
         $readline->addHistory($line);
     }
 });

--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ $stdout = $stdio->getOutput();
 
 #### Stdin
 
-The `Stdin` represents a `ReadableStream` and is responsible for handling console input.
+[Deprecated] The `Stdin` represents a `ReadableStream` and is responsible for handling console input.
 
 Interfacing with it directly is *not recommended* and considered *advanced usage*.
 
@@ -525,6 +525,7 @@ Should you need to interface with the `Stdin`, you can access the current instan
 You can access the current instance through the [`Stdio`](#stdio):
 
 ```php
+// deprecated
 $stdin = $stdio->getInput();
 ```
 

--- a/examples/02-interactive.php
+++ b/examples/02-interactive.php
@@ -21,16 +21,6 @@ if ($limit === '' || $limit < 0) {
     $readline->limitHistory($limit);
 }
 
-// add all lines from input to history
-$readline->on('data', function ($line) use ($readline) {
-    $all = $readline->listHistory();
-
-    // skip empty line and duplicate of previous line
-    if (trim($line) !== '' && $line !== end($all)) {
-        $readline->addHistory($line);
-    }
-});
-
 // autocomplete the following commands (at offset=0/1 only)
 $readline->setAutocomplete(function ($_, $offset) {
     return $offset > 1 ? array() : array('exit', 'quit', 'help', 'echo', 'print', 'printf');
@@ -39,8 +29,17 @@ $readline->setAutocomplete(function ($_, $offset) {
 $stdio->write('Welcome to this interactive demo' . PHP_EOL);
 
 // react to commands the user entered
-$stdio->on('data', function ($line) use ($stdio) {
-    $stdio->write('you just said: ' . addcslashes($line, "\0..\037") . ' (' . strlen($line) . ')' . PHP_EOL);
+$stdio->on('data', function ($line) use ($stdio, $readline) {
+    $line = rtrim($line, "\r\n");
+
+    // add all lines from input to history
+    // skip empty line and duplicate of previous line
+    $all = $readline->listHistory();
+    if ($line !== '' && $line !== end($all)) {
+        $readline->addHistory($line);
+    }
+
+    $stdio->write('you just said: ' . $line . ' (' . strlen($line) . ')' . PHP_EOL);
 
     if (in_array(trim($line), array('quit', 'exit'))) {
         $stdio->end();

--- a/examples/02-interactive.php
+++ b/examples/02-interactive.php
@@ -39,8 +39,8 @@ $readline->setAutocomplete(function ($_, $offset) {
 $stdio->write('Welcome to this interactive demo' . PHP_EOL);
 
 // react to commands the user entered
-$stdio->on('line', function ($line) use ($stdio) {
-    $stdio->write('you just said: ' . $line . ' (' . strlen($line) . ')' . PHP_EOL);
+$stdio->on('data', function ($line) use ($stdio) {
+    $stdio->write('you just said: ' . addcslashes($line, "\0..\037") . ' (' . strlen($line) . ')' . PHP_EOL);
 
     if (in_array(trim($line), array('quit', 'exit'))) {
         $stdio->end();

--- a/examples/03-commander.php
+++ b/examples/03-commander.php
@@ -46,11 +46,13 @@ $readline->setAutocomplete(function ($_, $offset) {
 $stdio->write('Welcome to this interactive demo' . PHP_EOL);
 
 // react to commands the user entered
-$stdio->on('line', function ($line) use ($router, $stdio, $readline) {
+$stdio->on('data', function ($line) use ($router, $stdio, $readline) {
+    $line = rtrim($line, "\r\n");
+
     // add all lines from input to history
     // skip empty line and duplicate of previous line
     $all = $readline->listHistory();
-    if (trim($line) !== '' && $line !== end($all)) {
+    if ($line !== '' && $line !== end($all)) {
         $readline->addHistory($line);
     }
 

--- a/examples/11-login.php
+++ b/examples/11-login.php
@@ -14,7 +14,8 @@ $first = true;
 $username = null;
 $password = null;
 
-$stdio->on('line', function ($line) use ($stdio, &$first, &$username, &$password) {
+$stdio->on('data', function ($line) use ($stdio, &$first, &$username, &$password) {
+    $line = rtrim($line, "\r\n");
     if ($first) {
         $stdio->getReadline()->setPrompt('Password: ');
         $stdio->getReadline()->setEcho('*');

--- a/src/Stdin.php
+++ b/src/Stdin.php
@@ -5,7 +5,9 @@ namespace Clue\React\Stdio;
 use React\Stream\Stream;
 use React\EventLoop\LoopInterface;
 
-// TODO: only implement ReadableStream
+/**
+ * @deprecated
+ */
 class Stdin extends Stream
 {
     private $oldMode = null;

--- a/src/Stdio.php
+++ b/src/Stdio.php
@@ -217,6 +217,9 @@ class Stdio extends EventEmitter implements DuplexStreamInterface
         $this->output->close();
     }
 
+    /**
+     * @deprecated
+     */
     public function getInput()
     {
         return $this->input;


### PR DESCRIPTION
This is done as preparation for #50 
Builds on top of #59