### PR TITLE
Consistently emit incoming "data" event with trailing newline

### DIFF
--- a/src/Readline.php
+++ b/src/Readline.php
@@ -628,7 +628,7 @@ class Readline extends EventEmitter implements ReadableStreamInterface
         if ($this->echo !== false) {
             $this->output->write("\n");
         }
-        $this->processLine();
+        $this->processLine("\n");
     }
 
     /** @internal */
@@ -741,7 +741,7 @@ class Readline extends EventEmitter implements ReadableStreamInterface
      *
      * @uses self::setInput()
      */
-    protected function processLine()
+    protected function processLine($eol)
     {
         // reset history cycle position
         $this->historyPosition = null;
@@ -758,7 +758,7 @@ class Readline extends EventEmitter implements ReadableStreamInterface
         }
 
         // process stored input buffer
-        $this->emit('data', array($line));
+        $this->emit('data', array($line . $eol));
     }
 
     private function strlen($str)
@@ -818,7 +818,7 @@ class Readline extends EventEmitter implements ReadableStreamInterface
     public function handleEnd()
     {
         if ($this->linebuffer !== '') {
-            $this->processLine();
+            $this->processLine('');
         }
 
         if (!$this->closed) {

--- a/src/Stdio.php
+++ b/src/Stdio.php
@@ -46,9 +46,7 @@ class Stdio extends EventEmitter implements DuplexStreamInterface
         $this->readline->on('data', function($line) use ($that, &$incomplete) {
             // readline emits a new line on enter, so start with a blank line
             $incomplete = '';
-
-            // emit data with trailing newline in order to preserve readable API
-            $that->emit('data', array($line . PHP_EOL));
+            $that->emit('data', array($line));
         });
 
         // handle all input events (readline forwards all input events)

--- a/tests/ReadlineTest.php
+++ b/tests/ReadlineTest.php
@@ -193,7 +193,7 @@ class ReadlineTest extends TestCase
 
     public function testDataEventWillBeEmittedForCompleteLine()
     {
-        $this->readline->on('data', $this->expectCallableOnceWith('hello'));
+        $this->readline->on('data', $this->expectCallableOnceWith("hello\n"));
 
         $this->input->emit('data', array("hello\n"));
     }
@@ -209,7 +209,7 @@ class ReadlineTest extends TestCase
 
     public function testDataEventWillBeEmittedForCompleteLineAndRemainingWillStayInInputBuffer()
     {
-        $this->readline->on('data', $this->expectCallableOnceWith('hello'));
+        $this->readline->on('data', $this->expectCallableOnceWith("hello\n"));
 
         $this->input->emit('data', array("hello\nworld"));
 
@@ -218,7 +218,7 @@ class ReadlineTest extends TestCase
 
     public function testDataEventWillBeEmittedForEmptyLine()
     {
-        $this->readline->on('data', $this->expectCallableOnceWith(''));
+        $this->readline->on('data', $this->expectCallableOnceWith("\n"));
 
         $this->input->emit('data', array("\n"));
     }
@@ -905,14 +905,14 @@ class ReadlineTest extends TestCase
 
     public function testEmitEmptyInputOnEnter()
     {
-        $this->readline->on('data', $this->expectCallableOnceWith(''));
+        $this->readline->on('data', $this->expectCallableOnceWith("\n"));
         $this->readline->onKeyEnter();
     }
 
     public function testEmitInputOnEnterAndClearsInput()
     {
         $this->readline->setInput('test');
-        $this->readline->on('data', $this->expectCallableOnceWith('test'));
+        $this->readline->on('data', $this->expectCallableOnceWith("test\n"));
         $this->readline->onKeyEnter();
 
         $this->assertEquals('', $this->readline->getInput());

--- a/tests/StdioTest.php
+++ b/tests/StdioTest.php
@@ -383,7 +383,22 @@ class StdioTest extends TestCase
 
         $stdio->on('data', $this->expectCallableOnceWith("hello\n"));
 
-        $readline->emit('data', array('hello'));
+        $readline->emit('data', array("hello\n"));
+    }
+
+    public function testDataEventWithoutNewlineWillBeForwardedAsIs()
+    {
+        $input = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
+        $output = $this->getMockBuilder('React\Stream\WritableStreamInterface')->getMock();
+
+        //$readline = $this->getMockBuilder('Clue\React\Stdio\Readline')->disableOriginalConstructor()->getMock();
+        $readline = new Readline($input, $output);
+
+        $stdio = new Stdio($this->loop, $input, $output, $readline);
+
+        $stdio->on('data', $this->expectCallableOnceWith("hello"));
+
+        $readline->emit('data', array("hello"));
     }
 
     public function testEndEventWillBeForwarded()


### PR DESCRIPTION
Builds on top of #56